### PR TITLE
Changes to make right-clicking not crash on server 0.4.13 git 2016-02-20

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ based on glomie's mod, remade by Zeg9 and reworked by TenPlus1.
 
 expertmm version changes:
 * (no other changes)
-* readme incorrectly called the mod [protect] where it should be [protector] according to the parent used by the lua scripts
+* readme incorrectly called the mod [protect] where it should be [protector] according to the parent used by the lua scripts and forum post https://forum.minetest.net/viewtopic.php?f=9&t=9376
 * fix crashes by doing nil checking
 
 https://forum.minetest.net/viewtopic.php?f=11&t=9376

--- a/README.md
+++ b/README.md
@@ -1,10 +1,16 @@
-expertmm Protector mod [protect]
-based on Protector Redo mod [protect] by TenPlus1
+# protect
+expertmm Protector mod [protector]
+based on Protector Redo mod [protector] by TenPlus1
 
 Protector redo for minetest is a mod that protects a players builds by placing
 a block that stops other players from digging or placing blocks in that area.
 
 based on glomie's mod, remade by Zeg9 and reworked by TenPlus1.
+
+expertmm version changes:
+* (no other changes)
+* readme incorrectly called the mod [protect] where it should be [protector] according to the parent used by the lua scripts
+* fix crashes by doing nil checking
 
 https://forum.minetest.net/viewtopic.php?f=11&t=9376
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-Protector Redo mod [protect]
+expertmm Protector mod [protect]
+based on Protector Redo mod [protect] by TenPlus1
 
 Protector redo for minetest is a mod that protects a players builds by placing
 a block that stops other players from digging or placing blocks in that area.

--- a/REASON FOR FORK.txt
+++ b/REASON FOR FORK.txt
@@ -1,0 +1,16 @@
+Problems with 2016-02-20 github version of tenplus1/protector vs the 2016-02-20 github version of minetestserver:
+
+RIGHT-CLICK PROTECTOR BLOCK:
+
+2016-02-20 22:12:37: ERROR[Main]: ServerError: Lua: Runtime error from mod '' in callback item_OnPlace(): /usr/local/share/minetest/games/fca_game_a/mods/protector/init.lua:68: attempt to concatenate field 'gui_slots' (a nil value)
+2016-02-20 22:12:37: ERROR[Main]: stack traceback:
+2016-02-20 22:12:37: ERROR[Main]:       /usr/local/share/minetest/games/fca_game_a/mods/protector/init.lua:68: in function 'generate_formspec'
+2016-02-20 22:12:37: ERROR[Main]:       /usr/local/share/minetest/games/fca_game_a/mods/protector/init.lua:325: in function 'on_rightclick'
+2016-02-20 22:12:37: ERROR[Main]:       /usr/local/share/minetest/builtin/game/item.lua:332: in function </usr/local/share/minetest/builtin/game/item.lua:325>
+
+RIGHT CLICK PROTECTED CHEST:
+
+2016-02-20 22:59:28: ERROR[Main]: ServerError: Lua: Runtime error from mod '' in callback item_OnPlace(): /usr/local/share/minetest/games/fca_game_a/mods/protector/doors_chest.lua:553: attempt to call field 'get_hotbar_bg' (a nil value)
+2016-02-20 22:59:28: ERROR[Main]: stack traceback:
+2016-02-20 22:59:28: ERROR[Main]:       /usr/local/share/minetest/games/fca_game_a/mods/protector/doors_chest.lua:553: in function 'on_rightclick'
+2016-02-20 22:59:28: ERROR[Main]:       /usr/local/share/minetest/builtin/game/item.lua:332: in function </usr/local/share/minetest/builtin/game/item.lua:325>

--- a/doors_chest.lua
+++ b/doors_chest.lua
@@ -560,9 +560,12 @@ minetest.register_node("protector:chest", {
 			.. "listring[nodemeta:" .. spos .. ";main]"
 			.. "listring[current_player;main]"
 		if default ~= nil then
-			local got_hotbar = default.get_hotbar_bg(0,5)
-			if got_hotbar ~= nil then
-				formspec = formspec .. got_hotbar
+			local got_hotbar = nil
+			if default.get_hotbar_bg ~= nil then
+				got_hotbar = default.get_hotbar_bg(0,5)
+				if got_hotbar ~= nil then
+					formspec = formspec .. got_hotbar
+				end
 			end
 		end
 		minetest.show_formspec(

--- a/doors_chest.lua
+++ b/doors_chest.lua
@@ -538,10 +538,16 @@ minetest.register_node("protector:chest", {
 		local meta = minetest.get_meta(pos)
 		local spos = pos.x .. "," .. pos.y .. "," ..pos.z
 		local formspec = "size[8,9]"
-			.. default.gui_bg
-			.. default.gui_bg_img
-		if default ~= nil and default.gui_slots ~= nil then
-			formspec = formspec .. default.gui_slots
+		if default ~= nil then
+			if default.gui_bg ~= nil then
+				formspec = formspec .. default.gui_bg
+			end
+			if default.gui_bg_img ~= nil then
+				formspec = formspec .. default.gui_bg_img
+			end
+			if default.gui_slots ~= nil then
+				formspec = formspec .. default.gui_slots
+			end
 		end
 		formspec = formspec
 			.. "list[nodemeta:".. spos .. ";main;0,0.3;8,4;]"

--- a/doors_chest.lua
+++ b/doors_chest.lua
@@ -540,7 +540,10 @@ minetest.register_node("protector:chest", {
 		local formspec = "size[8,9]"
 			.. default.gui_bg
 			.. default.gui_bg_img
-			.. default.gui_slots
+		if default ~= nil and default.gui_slots ~= nil then
+			formspec = formspec .. default.gui_slots
+		end
+		formspec = formspec
 			.. "list[nodemeta:".. spos .. ";main;0,0.3;8,4;]"
 			.. "button[0,4.5;2,0.25;toup;To Chest]"
 			.. "field[2.3,4.8;4,0.25;chestname;;"
@@ -550,12 +553,16 @@ minetest.register_node("protector:chest", {
 			.. "list[current_player;main;0,6.08;8,3;8]"
 			.. "listring[nodemeta:" .. spos .. ";main]"
 			.. "listring[current_player;main]"
-			.. default.get_hotbar_bg(0,5)
-
-			minetest.show_formspec(
-				clicker:get_player_name(),
-				"protector:chest_" .. minetest.pos_to_string(pos),
-				formspec)
+		if default ~= nil then
+			local got_hotbar = default.get_hotbar_bg(0,5)
+			if got_hotbar ~= nil then
+				formspec = formspec .. got_hotbar
+			end
+		end
+		minetest.show_formspec(
+			clicker:get_player_name(),
+			"protector:chest_" .. minetest.pos_to_string(pos),
+			formspec)
 	end,
 
 	on_blast = function() end,

--- a/init.lua
+++ b/init.lua
@@ -60,11 +60,17 @@ end
 
 protector.generate_formspec = function(meta)
 	
-	local formspec = "size[8,7]"..
-		default.gui_bg..
-		default.gui_bg_img
-	if default ~= nil and default.gui_slots ~= nil then
-		formspec = formspec .. default.gui_slots
+	local formspec = "size[8,7]"
+	if default ~= nil then
+		if default.gui_slots ~= nil then
+			formspec = formspec .. default.gui_bg
+		end
+		if default.gui_slots ~= nil then
+			formspec = formspec .. default.gui_bg_img
+		end
+		if default.gui_slots ~= nil then
+			formspec = formspec .. default.gui_slots
+		end
 	end
 	formspec = formspec .. "label[2.5,0;-- Protector interface --]"
 		.."label[0,1;PUNCH node to show protected area or USE for area check]"

--- a/init.lua
+++ b/init.lua
@@ -59,10 +59,14 @@ end
 -- Protector Interface
 
 protector.generate_formspec = function(meta)
-
-	local formspec = "size[8,7]"
-		..default.gui_bg..default.gui_bg_img..default.gui_slots
-		.."label[2.5,0;-- Protector interface --]"
+	
+	local formspec = "size[8,7]"..
+		default.gui_bg..
+		default.gui_bg_img..
+	if default ~= nil and default.gui_slots ~= nil then
+		formspec = formspec .. default.gui_slots..
+	end
+	formspec = formspec .. "label[2.5,0;-- Protector interface --]"
 		.."label[0,1;PUNCH node to show protected area or USE for area check]"
 		.."label[0,2;Members: (type player name then press Enter to add)]"
 		.. "button_exit[2.5,6.2;3,0.5;close_me;Close]"
@@ -319,10 +323,11 @@ minetest.register_node("protector:protect", {
 	on_rightclick = function(pos, node, clicker, itemstack)
 
 		local meta = minetest.get_meta(pos)
-
-		if protector.can_dig(1, pos,clicker:get_player_name(), true, 1) then
-			minetest.show_formspec(clicker:get_player_name(), 
-			"protector:node_" .. minetest.pos_to_string(pos), protector.generate_formspec(meta))
+		if meta ~= nil then
+			if protector.can_dig(1, pos,clicker:get_player_name(), true, 1) then
+				minetest.show_formspec(clicker:get_player_name(), 
+				"protector:node_" .. minetest.pos_to_string(pos), protector.generate_formspec(meta))
+			end
 		end
 	end,
 

--- a/init.lua
+++ b/init.lua
@@ -62,7 +62,7 @@ protector.generate_formspec = function(meta)
 	
 	local formspec = "size[8,7]"..
 		default.gui_bg..
-		default.gui_bg_img..
+		default.gui_bg_img
 	if default ~= nil and default.gui_slots ~= nil then
 		formspec = formspec .. default.gui_slots..
 	end

--- a/init.lua
+++ b/init.lua
@@ -64,7 +64,7 @@ protector.generate_formspec = function(meta)
 		default.gui_bg..
 		default.gui_bg_img
 	if default ~= nil and default.gui_slots ~= nil then
-		formspec = formspec .. default.gui_slots..
+		formspec = formspec .. default.gui_slots
 	end
 	formspec = formspec .. "label[2.5,0;-- Protector interface --]"
 		.."label[0,1;PUNCH node to show protected area or USE for area check]"

--- a/init.lua
+++ b/init.lua
@@ -62,10 +62,10 @@ protector.generate_formspec = function(meta)
 	
 	local formspec = "size[8,7]"
 	if default ~= nil then
-		if default.gui_slots ~= nil then
+		if default.gui_bg ~= nil then
 			formspec = formspec .. default.gui_bg
 		end
-		if default.gui_slots ~= nil then
+		if default.gui_bg_img ~= nil then
 			formspec = formspec .. default.gui_bg_img
 		end
 		if default.gui_slots ~= nil then


### PR DESCRIPTION
Hello, please review and merge these changes (other than the README and REASON FOR FORK files). I'm not sure why the members of default you are trying to access are nil--perhaps on an older version of minetest or on single player the problem did not exist yet. However, since I made no changes other than nil checking (feel free to review), my changes will not break compatibility (just to be clear, every place where I check for a nil, there in fact IS a nil when mod runs in the minetest-server version mentioned above). The right-click gui seems to work fine now (instead of crashing)--for example, after adding names to the protector block, it remembers them. I'm not sure what functionality is missing when the values are nil, but in my version they will be used if they are not nil so there shouldn't be a compatibility problem. Perhaps you or someone who knows more about the problem could fix it further and somehow get those members of default (other mods, including ones included in minetest_game 0.4.13 stable, such as bones, use those same members for formspec in a different scope, and there is no crash).