### PR TITLE
Make the protector placer tool check all nodes under the player in protected area

### DIFF
--- a/tool.lua
+++ b/tool.lua
@@ -10,17 +10,20 @@ minetest.register_craftitem("protector:tool", {
 
 		local name = user:get_player_name()
 
-		-- check node player occupies
+		-- check nodes under player
 		local pos = user:getpos()
-		local nod = minetest.get_node(pos).name
-		if nod ~= "protector:protect2" then
-			-- check node under player
-			pos.y = pos.y - 1
+		local nod
+		for _ = 1, protector.radius*2 + 1 do
 			nod = minetest.get_node(pos).name
-			if nod ~= "protector:protect"
-			and nod ~= "protector:protect2" then
-				return
+			if nod == "protector:protect"
+			or nod == "protector:protect2" then
+				break
 			end
+			pos.y = pos.y - 1
+		end
+		if nod ~= "protector:protect"
+		and nod ~= "protector:protect2" then
+			return
 		end
 
 		-- get members on protector


### PR DESCRIPTION
If protectors are placed under the ground to hide them from view, it is convenient to be able to copy them in a perfect grid without having to dig to stand exactly on the protector. This pull request makes that possible by making the protector tool search for a protector under the player. The tool uses the first protector it finds, but the player must be in the area protected by the protection block or logo because the tool only checks twice the protection radius.